### PR TITLE
feat: enlarge header PMC logo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,7 +229,7 @@ export default function App() {
         <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
           {/* Logo */}
           <div
-            className="font-black text-2xl md:text-3xl tracking-tight select-none"
+            className="font-black text-3xl md:text-4xl tracking-tight select-none"
             aria-label="PMC logo"
             data-testid="logo"
           >


### PR DESCRIPTION
## Summary
- increase header PMC wordmark size for better visibility

## Testing
- `npm test` (fails: missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2554c9278832e826551e03c6f54d2