### PR TITLE
Link blog cards to placeholder pages

### DIFF
--- a/public/blog/case-study-automating-chassis-split-audits-with-mcp.html
+++ b/public/blog/case-study-automating-chassis-split-audits-with-mcp.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Case Study: Automating Chassis Split Audits with MCP</title>
+  </head>
+  <body>
+    <h1>Case Study: Automating Chassis Split Audits with MCP</h1>
+    <p>Lorem Epsom dolor sit amet, consectetur adipiscing elit. Lorem Epsom dolor sit amet.</p>
+    <p><a href="/">Back to home</a></p>
+  </body>
+</html>

--- a/public/blog/from-google-sheets-to-live-kpis-in-48-hours.html
+++ b/public/blog/from-google-sheets-to-live-kpis-in-48-hours.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>From Google Sheets to Live KPIs in 48 Hours</title>
+  </head>
+  <body>
+    <h1>From Google Sheets to Live KPIs in 48 Hours</h1>
+    <p>Lorem Epsom dolor sit amet, consectetur adipiscing elit. Lorem Epsom dolor sit amet.</p>
+    <p><a href="/">Back to home</a></p>
+  </body>
+</html>

--- a/public/blog/wiring-lsp-data-into-command-lessons-learned.html
+++ b/public/blog/wiring-lsp-data-into-command-lessons-learned.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Wiring LSP Data into Command: Lessons Learned</title>
+  </head>
+  <body>
+    <h1>Wiring LSP Data into Command: Lessons Learned</h1>
+    <p>Lorem Epsom dolor sit amet, consectetur adipiscing elit. Lorem Epsom dolor sit amet.</p>
+    <p><a href="/">Back to home</a></p>
+  </body>
+</html>

--- a/public/blog/zapier-vs-retool-for-logistics-workflows.html
+++ b/public/blog/zapier-vs-retool-for-logistics-workflows.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Zapier vs Retool for Logistics Workflows</title>
+  </head>
+  <body>
+    <h1>Zapier vs Retool for Logistics Workflows</h1>
+    <p>Lorem Epsom dolor sit amet, consectetur adipiscing elit. Lorem Epsom dolor sit amet.</p>
+    <p><a href="/">Back to home</a></p>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,7 +370,12 @@ export default function App() {
                   <span key={t} className="text-xs border border-black/20 rounded-full px-2 py-0.5">{t}</span>
                 ))}
               </div>
-              <a href="#" className="mt-4 inline-block text-sm underline underline-offset-4">Read more</a>
+              <a
+                href={`/blog/${slug(p.title)}.html`}
+                className="mt-4 inline-block text-sm underline underline-offset-4"
+              >
+                Read more
+              </a>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Link blog card "Read more" anchors to individual HTML pages via slugified titles
- Add placeholder HTML pages for each blog post containing temporary "Lorem Epsom" text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a551068832e92fa2f8727a9448d