### PR TITLE
style: match header consult button color to hero link

### DIFF
--- a/src/BlogPost.tsx
+++ b/src/BlogPost.tsx
@@ -23,7 +23,7 @@ export default function BlogPost() {
             target="_blank"
             rel="noreferrer"
             data-testid="header-cta"
-            className="rounded-full border border-black px-4 py-2 text-sm font-medium text-blue-600 hover:bg-black hover:text-white transition"
+            className="rounded-full border border-indigo-600 text-indigo-600 px-5 py-2.5 text-sm font-medium hover:bg-indigo-600 hover:text-white transition"
           >
             Schedule a Consult
           </a>

--- a/src/BlogPost.tsx
+++ b/src/BlogPost.tsx
@@ -23,7 +23,7 @@ export default function BlogPost() {
             target="_blank"
             rel="noreferrer"
             data-testid="header-cta"
-            className="rounded-full border border-black px-4 py-2 text-sm font-medium hover:bg-black hover:text-white transition"
+            className="rounded-full border border-black px-4 py-2 text-sm font-medium text-blue-600 hover:bg-black hover:text-white transition"
           >
             Schedule a Consult
           </a>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -215,7 +215,7 @@ export default function Home() {
             target="_blank"
             rel="noreferrer"
             data-testid="header-cta"
-            className="rounded-full border border-black px-4 py-2 text-sm font-medium text-blue-600 hover:bg-black hover:text-white transition"
+            className="rounded-full border border-indigo-600 text-indigo-600 px-5 py-2.5 text-sm font-medium hover:bg-indigo-600 hover:text-white transition"
           >
             Schedule a Consult
           </a>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -215,7 +215,7 @@ export default function Home() {
             target="_blank"
             rel="noreferrer"
             data-testid="header-cta"
-            className="rounded-full border border-black px-4 py-2 text-sm font-medium hover:bg-black hover:text-white transition"
+            className="rounded-full border border-black px-4 py-2 text-sm font-medium text-blue-600 hover:bg-black hover:text-white transition"
           >
             Schedule a Consult
           </a>


### PR DESCRIPTION
## Summary
- make top-right "Schedule a Consult" button use blue text like "See What We Do" on all pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae418a6158832e8f8f8f6345aabce9