### PR TITLE
feat: make sticky cta button indigo

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -341,7 +341,7 @@ export default function Home() {
         <a
           href={nextHref}
           data-testid="sticky-cta"
-          className="rounded-full border border-black bg-white px-5 py-2.5 text-sm font-medium shadow hover:bg-black hover:text-white transition"
+          className="rounded-full border border-indigo-600 bg-indigo-600 px-5 py-2.5 text-sm font-medium text-white shadow hover:bg-indigo-600 hover:text-white transition"
           onClick={(e) => {
             if (nextLabel === "Back to top") {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- style sticky bottom CTA with an indigo border and background, white text by default

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae44b5e994832e9009ab9169adfdfb